### PR TITLE
Filtering Support for RandomEvents, fixed PictureUrl replacement bug

### DIFF
--- a/EventCatalogApi/Controllers/CatalogController.cs
+++ b/EventCatalogApi/Controllers/CatalogController.cs
@@ -157,10 +157,7 @@ namespace EventCatalogApi.Controllers
                 .Take(pageSize)
                 .ToListAsync();
 
-            pageOfEvents.ForEach(e =>
-                e.PictureUrl = e.PictureUrl.Replace(
-                "http://externalcatalogbaseurltobereplaced",
-                _config["ExternalCatalogBaseUrl"]));
+            ReplacePictureUrlPlaceholdersWithExternalCatalogBaseUrl(pageOfEvents);
 
             var viewModel = new PaginatedItemsViewModel<CatalogEvent>
             {
@@ -187,6 +184,15 @@ namespace EventCatalogApi.Controllers
 
             return Ok(viewModel);
         }
+
+        // Arrow notation for method definition (like a lambda but not)
+        private void ReplacePictureUrlPlaceholdersWithExternalCatalogBaseUrl(
+            List<CatalogEvent> events) =>
+                events.ForEach(e =>
+                    e.PictureUrl = e.PictureUrl.Replace(
+                        "http://externalcatalogbaseurltobereplaced",
+                        _config["ExternalCatalogBaseUrl"]));
+
 
         private IQueryable<CatalogEvent> GetFilteredEventsQuery(
             int? catalogFormatId,
@@ -317,6 +323,8 @@ namespace EventCatalogApi.Controllers
 
                         randomEvents.Add(randomEvent);
                     }
+
+                    ReplacePictureUrlPlaceholdersWithExternalCatalogBaseUrl(randomEvents);
 
 
                     //var query2 = (IQueryable<CatalogEvent>)_context.CatalogEvents;

--- a/EventCatalogApi/Controllers/CatalogController.cs
+++ b/EventCatalogApi/Controllers/CatalogController.cs
@@ -306,6 +306,10 @@ namespace EventCatalogApi.Controllers
                                          .ToList();
 
 
+
+
+                    // Source code for EF Core 3.1.0:
+                    // https://github.com/dotnet/efcore/tree/v3.1.0/src
                     foreach (var index in randomIndices)
                     {
                         var query = filteredEvents.Skip(index);


### PR DESCRIPTION
(EventCatalogApi)
CatalogController
Refactored events filtering into private helper method: GetFilteredEventsQuery

Improved names of vars post-filtered-events refactor

(EventCatalogApi)
CatalogController
Refactored image replacement into helper method:
ReplacePictureUrlPlaceholdersWithExternalCatalogBaseUrl

Fixed bug where RandomEvents did not replace the placeholders in the PictureUrl properties of its CatalogEvents